### PR TITLE
Bump spring.version in /JacpFX-ui-composition

### DIFF
--- a/JacpFX-ui-composition/pom.xml
+++ b/JacpFX-ui-composition/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jacp.version>2.0.2</jacp.version>
-        <spring.version>4.0.0.RELEASE</spring.version>
+        <spring.version>5.2.3.RELEASE</spring.version>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
Bumps `spring.version` from 4.0.0.RELEASE to 5.2.3.RELEASE.

Updates `spring-core` from 4.0.0.RELEASE to 5.2.3.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.0.0.RELEASE...v5.2.3.RELEASE)

Updates `spring-context` from 4.0.0.RELEASE to 5.2.3.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.0.0.RELEASE...v5.2.3.RELEASE)

Updates `spring-beans` from 4.0.0.RELEASE to 5.2.3.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.0.0.RELEASE...v5.2.3.RELEASE)

Updates `spring-expression` from 4.0.0.RELEASE to 5.2.3.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.0.0.RELEASE...v5.2.3.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>